### PR TITLE
Make version checks non-blocking and fix startup freeze

### DIFF
--- a/CC Settings/Views/General/GeneralSettingsView.swift
+++ b/CC Settings/Views/General/GeneralSettingsView.swift
@@ -862,9 +862,9 @@ struct GeneralSettingsView: View {
             let pipe = Pipe()
             let outputLock = NSLock()
             var collected = Data()
-            var processRef: Process? = process
-            var pipeRef: Pipe? = pipe
-            var didCloseHandle = false
+            var processRetainer: Process? = process
+            var pipeRetainer: Pipe? = pipe
+            var isHandleClosed = false
 
             process.executableURL = URL(fileURLWithPath: resolved)
             process.arguments = args
@@ -877,10 +877,10 @@ struct GeneralSettingsView: View {
                 outputLock.lock()
                 defer { outputLock.unlock() }
                 guard !chunk.isEmpty else {
-                    fileHandle.readabilityHandler = nil
-                    if !didCloseHandle {
+                    if !isHandleClosed {
+                        fileHandle.readabilityHandler = nil
                         fileHandle.closeFile()
-                        didCloseHandle = true
+                        isHandleClosed = true
                     }
                     return
                 }
@@ -890,19 +890,19 @@ struct GeneralSettingsView: View {
             process.terminationHandler = { _ in
                 outputLock.lock()
                 defer { outputLock.unlock() }
-                handle.readabilityHandler = nil
-                if !didCloseHandle {
+                if !isHandleClosed {
+                    handle.readabilityHandler = nil
                     let remainder = handle.availableData
                     if !remainder.isEmpty {
                         collected.append(remainder)
                     }
                     handle.closeFile()
-                    didCloseHandle = true
+                    isHandleClosed = true
                 }
                 let output = String(data: collected, encoding: .utf8) ?? ""
                 continuation.resume(returning: output)
-                pipeRef = nil
-                processRef = nil
+                pipeRetainer = nil
+                processRetainer = nil
             }
 
             do {
@@ -910,13 +910,13 @@ struct GeneralSettingsView: View {
             } catch {
                 outputLock.lock()
                 defer { outputLock.unlock() }
-                handle.readabilityHandler = nil
-                if !didCloseHandle {
+                if !isHandleClosed {
+                    handle.readabilityHandler = nil
                     handle.closeFile()
-                    didCloseHandle = true
+                    isHandleClosed = true
                 }
-                pipeRef = nil
-                processRef = nil
+                pipeRetainer = nil
+                processRetainer = nil
                 continuation.resume(returning: "Error: \(error.localizedDescription)")
             }
         }

--- a/CC Settings/Views/General/GeneralSettingsView.swift
+++ b/CC Settings/Views/General/GeneralSettingsView.swift
@@ -232,8 +232,11 @@ struct GeneralSettingsView: View {
             Text("Claude Code")
         }
         .onAppear {
-            fetchInstalledVersion()
-            checkForUpdates()
+            Task { @MainActor in
+                await Task.yield()
+                fetchInstalledVersion()
+                checkForUpdates()
+            }
         }
     }
 
@@ -854,20 +857,44 @@ struct GeneralSettingsView: View {
             resolved = command
         }
 
-        let process = Process()
-        let pipe = Pipe()
-        process.executableURL = URL(fileURLWithPath: resolved)
-        process.arguments = args
-        process.standardOutput = pipe
-        process.standardError = pipe
+        return await withCheckedContinuation { continuation in
+            let process = Process()
+            let pipe = Pipe()
+            let outputQueue = DispatchQueue(label: "GeneralSettingsView.runShell")
+            var collected = Data()
 
-        do {
-            try process.run()
-            process.waitUntilExit()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            return String(data: data, encoding: .utf8) ?? ""
-        } catch {
-            return "Error: \(error.localizedDescription)"
+            process.executableURL = URL(fileURLWithPath: resolved)
+            process.arguments = args
+            process.standardOutput = pipe
+            process.standardError = pipe
+
+            let handle = pipe.fileHandleForReading
+            handle.readabilityHandler = { fileHandle in
+                let chunk = fileHandle.availableData
+                guard !chunk.isEmpty else { return }
+                outputQueue.sync {
+                    collected.append(chunk)
+                }
+            }
+
+            process.terminationHandler = { _ in
+                handle.readabilityHandler = nil
+                let remainder = handle.availableData
+                outputQueue.sync {
+                    if !remainder.isEmpty {
+                        collected.append(remainder)
+                    }
+                    let output = String(data: collected, encoding: .utf8) ?? ""
+                    continuation.resume(returning: output)
+                }
+            }
+
+            do {
+                try process.run()
+            } catch {
+                handle.readabilityHandler = nil
+                continuation.resume(returning: "Error: \(error.localizedDescription)")
+            }
         }
     }
 

--- a/CC Settings/Views/General/GeneralSettingsView.swift
+++ b/CC Settings/Views/General/GeneralSettingsView.swift
@@ -862,8 +862,9 @@ struct GeneralSettingsView: View {
             let pipe = Pipe()
             let outputLock = NSLock()
             var collected = Data()
-            var retainedProcess: Process? = process
-            var retainedPipe: Pipe? = pipe
+            var processRef: Process? = process
+            var pipeRef: Pipe? = pipe
+            var didCloseHandle = false
 
             process.executableURL = URL(fileURLWithPath: resolved)
             process.arguments = args
@@ -873,12 +874,16 @@ struct GeneralSettingsView: View {
             let handle = pipe.fileHandleForReading
             handle.readabilityHandler = { fileHandle in
                 let chunk = fileHandle.availableData
-                guard !chunk.isEmpty else {
-                    fileHandle.readabilityHandler = nil
-                    return
-                }
                 outputLock.lock()
                 defer { outputLock.unlock() }
+                guard !chunk.isEmpty else {
+                    fileHandle.readabilityHandler = nil
+                    if !didCloseHandle {
+                        fileHandle.closeFile()
+                        didCloseHandle = true
+                    }
+                    return
+                }
                 collected.append(chunk)
             }
 
@@ -886,24 +891,32 @@ struct GeneralSettingsView: View {
                 outputLock.lock()
                 defer { outputLock.unlock() }
                 handle.readabilityHandler = nil
-                let remainder = handle.availableData
-                if !remainder.isEmpty {
-                    collected.append(remainder)
+                if !didCloseHandle {
+                    let remainder = handle.availableData
+                    if !remainder.isEmpty {
+                        collected.append(remainder)
+                    }
+                    handle.closeFile()
+                    didCloseHandle = true
                 }
-                handle.closeFile()
                 let output = String(data: collected, encoding: .utf8) ?? ""
                 continuation.resume(returning: output)
-                retainedPipe = nil
-                retainedProcess = nil
+                pipeRef = nil
+                processRef = nil
             }
 
             do {
                 try process.run()
             } catch {
+                outputLock.lock()
+                defer { outputLock.unlock() }
                 handle.readabilityHandler = nil
-                handle.closeFile()
-                retainedPipe = nil
-                retainedProcess = nil
+                if !didCloseHandle {
+                    handle.closeFile()
+                    didCloseHandle = true
+                }
+                pipeRef = nil
+                processRef = nil
                 continuation.resume(returning: "Error: \(error.localizedDescription)")
             }
         }

--- a/CC Settings/Views/General/GeneralSettingsView.swift
+++ b/CC Settings/Views/General/GeneralSettingsView.swift
@@ -865,6 +865,13 @@ struct GeneralSettingsView: View {
             var processRetainer: Process? = process
             var pipeRetainer: Pipe? = pipe
             var isHandleClosed = false
+            let closeHandleIfNeeded: (FileHandle) -> Void = { fileHandle in
+                if !isHandleClosed {
+                    fileHandle.readabilityHandler = nil
+                    fileHandle.closeFile()
+                    isHandleClosed = true
+                }
+            }
 
             process.executableURL = URL(fileURLWithPath: resolved)
             process.arguments = args
@@ -877,11 +884,7 @@ struct GeneralSettingsView: View {
                 outputLock.lock()
                 defer { outputLock.unlock() }
                 guard !chunk.isEmpty else {
-                    if !isHandleClosed {
-                        fileHandle.readabilityHandler = nil
-                        fileHandle.closeFile()
-                        isHandleClosed = true
-                    }
+                    closeHandleIfNeeded(fileHandle)
                     return
                 }
                 collected.append(chunk)
@@ -891,14 +894,12 @@ struct GeneralSettingsView: View {
                 outputLock.lock()
                 defer { outputLock.unlock() }
                 if !isHandleClosed {
-                    handle.readabilityHandler = nil
                     let remainder = handle.availableData
                     if !remainder.isEmpty {
                         collected.append(remainder)
                     }
-                    handle.closeFile()
-                    isHandleClosed = true
                 }
+                closeHandleIfNeeded(handle)
                 let output = String(data: collected, encoding: .utf8) ?? ""
                 continuation.resume(returning: output)
                 pipeRetainer = nil
@@ -910,11 +911,7 @@ struct GeneralSettingsView: View {
             } catch {
                 outputLock.lock()
                 defer { outputLock.unlock() }
-                if !isHandleClosed {
-                    handle.readabilityHandler = nil
-                    handle.closeFile()
-                    isHandleClosed = true
-                }
+                closeHandleIfNeeded(handle)
                 pipeRetainer = nil
                 processRetainer = nil
                 continuation.resume(returning: "Error: \(error.localizedDescription)")

--- a/CC Settings/Views/General/GeneralSettingsView.swift
+++ b/CC Settings/Views/General/GeneralSettingsView.swift
@@ -862,6 +862,8 @@ struct GeneralSettingsView: View {
             let pipe = Pipe()
             let outputLock = NSLock()
             var collected = Data()
+            var retainedProcess: Process? = process
+            var retainedPipe: Pipe? = pipe
 
             process.executableURL = URL(fileURLWithPath: resolved)
             process.arguments = args
@@ -871,7 +873,10 @@ struct GeneralSettingsView: View {
             let handle = pipe.fileHandleForReading
             handle.readabilityHandler = { fileHandle in
                 let chunk = fileHandle.availableData
-                guard !chunk.isEmpty else { return }
+                guard !chunk.isEmpty else {
+                    fileHandle.readabilityHandler = nil
+                    return
+                }
                 outputLock.lock()
                 defer { outputLock.unlock() }
                 collected.append(chunk)
@@ -885,14 +890,20 @@ struct GeneralSettingsView: View {
                 if !remainder.isEmpty {
                     collected.append(remainder)
                 }
+                handle.closeFile()
                 let output = String(data: collected, encoding: .utf8) ?? ""
                 continuation.resume(returning: output)
+                retainedPipe = nil
+                retainedProcess = nil
             }
 
             do {
                 try process.run()
             } catch {
                 handle.readabilityHandler = nil
+                handle.closeFile()
+                retainedPipe = nil
+                retainedProcess = nil
                 continuation.resume(returning: "Error: \(error.localizedDescription)")
             }
         }

--- a/CC Settings/Views/General/GeneralSettingsView.swift
+++ b/CC Settings/Views/General/GeneralSettingsView.swift
@@ -860,7 +860,7 @@ struct GeneralSettingsView: View {
         return await withCheckedContinuation { continuation in
             let process = Process()
             let pipe = Pipe()
-            let outputQueue = DispatchQueue(label: "GeneralSettingsView.runShell")
+            let outputLock = NSLock()
             var collected = Data()
 
             process.executableURL = URL(fileURLWithPath: resolved)
@@ -872,21 +872,21 @@ struct GeneralSettingsView: View {
             handle.readabilityHandler = { fileHandle in
                 let chunk = fileHandle.availableData
                 guard !chunk.isEmpty else { return }
-                outputQueue.sync {
-                    collected.append(chunk)
-                }
+                outputLock.lock()
+                collected.append(chunk)
+                outputLock.unlock()
             }
 
             process.terminationHandler = { _ in
                 handle.readabilityHandler = nil
                 let remainder = handle.availableData
-                outputQueue.sync {
-                    if !remainder.isEmpty {
-                        collected.append(remainder)
-                    }
-                    let output = String(data: collected, encoding: .utf8) ?? ""
-                    continuation.resume(returning: output)
+                outputLock.lock()
+                if !remainder.isEmpty {
+                    collected.append(remainder)
                 }
+                let output = String(data: collected, encoding: .utf8) ?? ""
+                outputLock.unlock()
+                continuation.resume(returning: output)
             }
 
             do {

--- a/CC Settings/Views/General/GeneralSettingsView.swift
+++ b/CC Settings/Views/General/GeneralSettingsView.swift
@@ -873,19 +873,19 @@ struct GeneralSettingsView: View {
                 let chunk = fileHandle.availableData
                 guard !chunk.isEmpty else { return }
                 outputLock.lock()
+                defer { outputLock.unlock() }
                 collected.append(chunk)
-                outputLock.unlock()
             }
 
             process.terminationHandler = { _ in
+                outputLock.lock()
+                defer { outputLock.unlock() }
                 handle.readabilityHandler = nil
                 let remainder = handle.availableData
-                outputLock.lock()
                 if !remainder.isEmpty {
                     collected.append(remainder)
                 }
                 let output = String(data: collected, encoding: .utf8) ?? ""
-                outputLock.unlock()
                 continuation.resume(returning: output)
             }
 


### PR DESCRIPTION
This pull request improves the responsiveness and reliability of the `GeneralSettingsView` in the settings UI, particularly around asynchronous operations and process output handling. The main changes focus on making UI updates more responsive and refactoring how subprocess output is collected to be fully asynchronous and thread-safe.

Improvements to asynchronous UI updates:

* Wrapped the `onAppear` logic in a `Task` with `@MainActor` and an `await Task.yield()` to ensure that UI updates related to version fetching and update checks are performed asynchronously and do not block the main thread.

Refactoring subprocess output handling:

* Refactored the subprocess execution logic to use `withCheckedContinuation` for fully asynchronous output collection, replaced synchronous output reading with a non-blocking handler using `readabilityHandler`, and added a lock (`NSLock`) to ensure thread-safe data collection. This change also ensures that any remaining output is collected after process termination and that errors are handled gracefully.